### PR TITLE
Breaking Change: Updated has_time_zone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ has_time_zone
 If you already have a time zone attribute on your class, but it is not named time_zone you can specify it's name.
 
 ```
-has_time_zone :my_whacky_time_zone
+has_time_zone named: :my_whacky_time_zone
 ```
 
 If you would like to specify specific date_time attributes that you would like affected you can do so like this.
@@ -38,7 +38,7 @@ has_time_zone   time_attributes: [:created_at, :start_time]
 Finally, you can also specify a time zone attribute and control the affected attributes.
 
 ```
-has_time_zone     :my_whacky_time_zone,
+has_time_zone     named: :my_whacky_time_zone,
                   time_attributes: [:created_at, :start_time]
 ```
 

--- a/lib/time_jawn/time_jawn.rb
+++ b/lib/time_jawn/time_jawn.rb
@@ -21,9 +21,10 @@ module TimeJawn
     #     end
     # Optionally you may pass the name of your time zone attribute in as a symbol.
     #     class Event<ActiveRecord::Base
-    #       has_time_zone    :this_is_my_time_zone
-    def has_time_zone(time_zone_attribute_name=:time_zone, options_hash={})
-      _set_instance_variables(time_zone_attribute_name, options_hash)
+    #       has_time_zone   named: :this_is_my_time_zone
+    #     end
+    def has_time_zone(options_hash={})
+      _set_instance_variables(options_hash)
       send :include, InstanceMethods
     end
   end

--- a/lib/time_jawn/time_jawn_private_class_methods.rb
+++ b/lib/time_jawn/time_jawn_private_class_methods.rb
@@ -13,28 +13,10 @@ module TimeJawnPrivateClassMethods
   end
 
   private
-  
-  def _set_instance_variables(time_zone_attribute_name, options_hash)
-    @time_zone_attribute_name = _evaluate_time_zone_attribute_name(time_zone_attribute_name)
-    @time_jawn_date_time_attributes = _evaluate_time_jawn_date_time_attributes(time_zone_attribute_name, options_hash)
-  end
 
-  def _evaluate_time_zone_attribute_name(time_zone_attribute_name)
-    if time_zone_attribute_name.kind_of?(Hash)
-      :time_zone
-    else
-      time_zone_attribute_name
-    end
-  end
-
-  def _evaluate_time_jawn_date_time_attributes(time_zone_attribute_name, options_hash)
-    if options_hash.fetch(:time_attributes, false)
-      @time_jawn_date_time_attributes = options_hash.fetch(:time_attributes, nil)
-    elsif time_zone_attribute_name.kind_of?(Hash)
-      @time_jawn_date_time_attributes = time_zone_attribute_name.fetch(:time_attributes, nil)
-    else
-      @time_jawn_date_time_attributes = nil
-    end
+  def _set_instance_variables(options_hash)
+    @time_zone_attribute_name = options_hash.fetch(:named, :time_zone)
+    @time_jawn_date_time_attributes = options_hash.fetch(:time_attributes, nil)
   end
 
   # generates an instance method called "local_#{attribute}" that calls the _to_local instance method.

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -2,7 +2,7 @@ class Happening < ActiveRecord::Base
 end
 
 class Event < ActiveRecord::Base
-  has_time_zone   :t_z
+  has_time_zone   named: :t_z
 end
 
 class Occurrence < ActiveRecord::Base
@@ -10,6 +10,5 @@ class Occurrence < ActiveRecord::Base
 end
 
 class Occasion < ActiveRecord::Base
-  has_time_zone   :t_z, 
-                    time_attributes: [:start_time]
+  has_time_zone   named: :t_z, time_attributes: [:start_time]
 end


### PR DESCRIPTION
Changes has_time_zone method to accept only an options hash. This simplifies attribute evaluation.